### PR TITLE
Add tab for sermons

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Faith Forward",
     "slug": "faith-forward",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "orientation": "portrait",
     "icon": "./assets/icon-dark-blue.png",
     "userInterfaceStyle": "light",
@@ -20,7 +20,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.phaedrus.faithforward",
-      "buildNumber": "10"
+      "buildNumber": "11"
     },
     "android": {
       "adaptiveIcon": {

--- a/firebase.ts
+++ b/firebase.ts
@@ -12,6 +12,7 @@ import {
   setDoc,
   updateDoc,
 } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
 
 const firebaseProdConfig = {
   apiKey: "AIzaSyDgj0UDgTub38VuhVjUFIe9Sc5U_ODJK1c",
@@ -39,6 +40,7 @@ const firebaseConfig =
 export const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 export const auth = getAuth(app);
+export const storage = getStorage(app);
 
 export interface PromptPayload {
   userInput: string;
@@ -103,7 +105,7 @@ export const syncPushToken = async (
         ...pushTokenData,
         timeZone,
         nextNotificationTime: nineAM.toISOString(),
-      }
+      };
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/stack": "^6.3.10",
     "axios": "^1.2.1",
     "expo": "~47.0.9",
+    "expo-av": "^13.0.2",
     "expo-dev-client": "~2.0.1",
     "expo-device": "~5.0.0",
     "expo-linear-gradient": "~12.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faith-forward",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",

--- a/src/hooks/useSermons.ts
+++ b/src/hooks/useSermons.ts
@@ -1,0 +1,40 @@
+import { collection, getDocs, query } from "firebase/firestore";
+import { useEffect, useState } from "react";
+import { db } from "../../firebase";
+import { TSermon } from "../../types";
+import useStore from "../Store";
+
+// TODO: Sort by createdAt
+export const useSermons = () => {
+  const [sermons, setSermons] = useState<TSermon[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { setError } = useStore();
+
+  // Fetch sermons from Firestore
+  const fetchSermons = async () => {
+    console.log("Fetching sermons...");
+    try {
+      let ss: TSermon[] = [];
+      const sermonsQuery = query(collection(db, "sermons"));
+      const snapshot = await getDocs(sermonsQuery);
+      if (snapshot.empty) {
+        console.log("No sermons found.");
+      }
+      snapshot.forEach((snap: any) => {
+        ss.push({ id: snap.id, ...snap.data() });
+      });
+      setSermons(ss);
+    } catch (error: any) {
+      console.error(error);
+      setError(error.toString());
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSermons();
+  }, []);
+
+  return { sermons, loading };
+};

--- a/src/hooks/useSermons.ts
+++ b/src/hooks/useSermons.ts
@@ -1,4 +1,4 @@
-import { collection, getDocs, query } from "firebase/firestore";
+import { collection, getDocs, orderBy, query } from "firebase/firestore";
 import { useEffect, useState } from "react";
 import { db } from "../../firebase";
 import { TSermon } from "../../types";
@@ -15,7 +15,10 @@ export const useSermons = () => {
     console.log("Fetching sermons...");
     try {
       let ss: TSermon[] = [];
-      const sermonsQuery = query(collection(db, "sermons"));
+      const sermonsQuery = query(
+        collection(db, "sermons"),
+        orderBy("createdAt", "desc")
+      );
       const snapshot = await getDocs(sermonsQuery);
       if (snapshot.empty) {
         console.log("No sermons found.");

--- a/src/screens/Navigation.tsx
+++ b/src/screens/Navigation.tsx
@@ -1,10 +1,11 @@
-import { FontAwesome, Ionicons } from "@expo/vector-icons";
+import { FontAwesome, Ionicons, FontAwesome5 } from "@expo/vector-icons";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import * as React from "react";
 import { Dimensions } from "react-native";
 import colors from "../styles/colors";
 import HomeNavigator from "./HomeNavigator";
 import ProfileScreen from "./ProfileScreen";
+import SermonsScreen from './SermonsScreen';
 
 const Tab = createBottomTabNavigator();
 
@@ -31,6 +32,15 @@ const BaseNavigator: React.FC = () => {
         options={{
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="md-sunny" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="Sermons"
+        component={SermonsScreen}
+        options={{
+          tabBarIcon: ({ color, size }) => (
+            <FontAwesome5 name="book-reader" size={size} color={color} />
           ),
         }}
       />

--- a/src/screens/SermonsScreen.tsx
+++ b/src/screens/SermonsScreen.tsx
@@ -72,21 +72,17 @@ export default function SermonsScreen() {
       }
     } else {
       if (playbackStatus.isPlaying) {
-        // TODO: Update your UI for the playing state
         console.log("Playing...");
       } else {
-        // TODO: Update your UI for the paused state
         console.log("Paused...");
       }
 
       if (playbackStatus.isBuffering) {
-        // TODO: Update your UI for the buffering state
         console.log("Buffering...");
       }
 
       if (playbackStatus.didJustFinish && !playbackStatus.isLooping) {
         console.log("Finished playing");
-        // The player has just finished playing and will stop
         setSound(null);
         setPlayingSermon(null);
         setIsPlaying(false);
@@ -130,9 +126,9 @@ export default function SermonsScreen() {
 
   return (
     <SafeAreaView style={styles.superContainer}>
-      <View style={styles.container}>
+      <ScrollView style={styles.container}>
         <Text style={styles.title}>Sermons</Text>
-        <ScrollView style={styles.sermonsContainer}>
+        <View style={styles.sermonsContainer}>
           {loading ? (
             <ActivityIndicator />
           ) : (
@@ -157,7 +153,7 @@ export default function SermonsScreen() {
               </View>
             ))
           )}
-        </ScrollView>
+        </View>
         {!!sound ? (
           <AudioControls
             title={playingSermon?.title || ""}
@@ -167,7 +163,7 @@ export default function SermonsScreen() {
             onStop={stopSound}
           />
         ) : null}
-      </View>
+      </ScrollView>
     </SafeAreaView>
   );
 }
@@ -216,7 +212,7 @@ function Sermon(props: SermonProps) {
     <View style={styles.sermonContainer}>
       <Text style={styles.sermonTitle}>{sermon.title}</Text>
       <Text style={styles.sermonDescription}>{sermon.description}</Text>
-      <Text style={styles.sermonDate}>{formatDate(sermon.createdAt)}</Text>
+      <Text style={styles.sermonSpeaker}>with {sermon.speaker}</Text>
     </View>
   );
 }
@@ -255,9 +251,10 @@ const styles = StyleSheet.create({
     fontSize: 16,
     paddingTop: 10,
   },
-  sermonDate: {
+  sermonSpeaker: {
     fontSize: 14,
     paddingVertical: 10,
+    fontStyle: "italic",
   },
   audioControlContainer: {
     position: "absolute",

--- a/src/screens/SermonsScreen.tsx
+++ b/src/screens/SermonsScreen.tsx
@@ -3,6 +3,7 @@ import { Audio } from "expo-av";
 import { getDownloadURL, ref } from "firebase/storage";
 import React, { useEffect, useState } from "react";
 import {
+  ActivityIndicator,
   SafeAreaView,
   StyleSheet,
   Text,
@@ -10,46 +11,69 @@ import {
   View,
 } from "react-native";
 import { storage } from "../../firebase";
+import { TSermon } from "../../types";
+import { useSermons } from "../hooks/useSermons";
 import colors from "../styles/colors";
+import { formatDate } from "../utils";
 
+// TODO: Style this puppy
 export default function SermonsScreen() {
+  const { sermons, loading } = useSermons();
   const [sound, setSound] = useState<any>();
+  const [playingFilename, setPlayingFilename] = useState<string | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
 
   useEffect(() => {
     return sound
       ? () => {
           console.log("Unloading sound...");
           sound.unloadAsync();
+          setPlayingFilename(null);
+          setIsPlaying(false);
         }
       : undefined;
   }, [sound]);
 
-  console.log("sound", sound);
+  useEffect(() => {
+    if (playingFilename) {
+      playSound();
+    }
+  }, [playingFilename]);
 
   async function pauseSound() {
     console.log("Pausing sound...");
     if (sound) {
       await sound.pauseAsync();
+      setIsPlaying(false);
     }
   }
 
-  async function stopSound() {
+  async function stopSound(): Promise<void> {
     console.log("Stopping sound...");
     if (sound) {
-      await sound.stopAsync();
-      await sound.unloadAsync();
+      if (sound.getStatusAsync().isLoaded) {
+        await sound.stopAsync();
+        await sound.unloadAsync();
+      }
       setSound(null);
+      setPlayingFilename(null);
+      setIsPlaying(false);
     }
   }
 
-  const playSound = async () => {
+  async function playSound(): Promise<void> {
     console.log("Playing sound...");
     if (sound) {
       console.log("Sound is loaded, resuming...");
       sound.playAsync();
     } else {
+      if (!playingFilename) {
+        console.error("Cannot play sound, no filename is set");
+        return;
+      }
+
       console.log("Sound is not loaded, loading...");
-      const sermon = ref(storage, "bella-on-love.mp3");
+      const sermon = ref(storage, playingFilename);
       const uri = await getDownloadURL(sermon);
       const { sound: playbackObject } = await Audio.Sound.createAsync(
         { uri },
@@ -57,75 +81,133 @@ export default function SermonsScreen() {
       );
       setSound(playbackObject);
     }
-  };
+    setIsPlaying(true);
+  }
 
-  // TODO: Return a list of all sermons in Firebase Storage
+  async function startPlayingSermon(sermon: TSermon) {
+    setPlayingFilename(sermon.filename);
+  }
+
   return (
-    <SafeAreaView style={styles.container}>
-      <Text style={styles.title}>Sermons</Text>
-      <Sermon onPlay={playSound} onPause={pauseSound} onStop={stopSound} />
+    <SafeAreaView style={styles.superContainer}>
+      <View style={styles.container}>
+        <Text style={styles.title}>Sermons</Text>
+        <View style={styles.sermonsContainer}>
+          {loading ? (
+            <ActivityIndicator />
+          ) : (
+            sermons.map((sermon) => (
+              <TouchableOpacity
+                key={sermon.id}
+                onPress={() => startPlayingSermon(sermon)}
+              >
+                <Sermon sermon={sermon} key={sermon.id} />
+              </TouchableOpacity>
+            ))
+          )}
+        </View>
+        {!!sound ? (
+          <AudioControls
+            playingAudio={isPlaying}
+            onPlay={playSound}
+            onPause={pauseSound}
+            onStop={stopSound}
+          />
+        ) : null}
+      </View>
     </SafeAreaView>
   );
 }
 
-interface SermonProps {
+interface AudioControlsProps {
+  playingAudio: boolean;
   onPlay: () => void;
   onPause: () => void;
   onStop: () => void;
 }
 
-function Sermon(props: SermonProps) {
-  const { onPlay, onPause, onStop } = props;
+function AudioControls(props: AudioControlsProps) {
+  const { playingAudio, onPlay, onPause, onStop } = props;
 
   return (
-      <View style={styles.sermonsContainer}>
-        <View>
-          <Text style={styles.sermonTitle}>On Love</Text>
-        </View>
-        <View style={styles.buttonContainer}>
-          <TouchableOpacity style={styles.button} onPress={onPlay}>
-            <FontAwesome5 name="play" size={24} color={colors.blue} />
-          </TouchableOpacity>
+    <View style={styles.buttonContainer}>
+      <>
+        {playingAudio ? (
           <TouchableOpacity style={styles.button} onPress={onPause}>
             <FontAwesome5 name="pause" size={24} color={colors.blue} />
           </TouchableOpacity>
-          <TouchableOpacity style={styles.button} onPress={onStop}>
-            <FontAwesome5 name="stop" size={24} color={colors.blue} />
+        ) : (
+          <TouchableOpacity style={styles.button} onPress={onPlay}>
+            <FontAwesome5 name="play" size={24} color={colors.blue} />
           </TouchableOpacity>
-        </View>
-      </View>
-  )
+        )}
+        <TouchableOpacity style={styles.button} onPress={onStop}>
+          <FontAwesome5 name="stop" size={24} color={colors.blue} />
+        </TouchableOpacity>
+      </>
+    </View>
+  );
+}
+
+interface SermonProps {
+  sermon: TSermon;
+}
+
+function Sermon(props: SermonProps) {
+  const { sermon } = props;
+
+  return (
+    <View style={styles.sermonContainer}>
+      <Text style={styles.sermonTitle}>{sermon.title}</Text>
+      <Text style={styles.sermonDescription}>{sermon.description}</Text>
+      <Text style={styles.sermonDate}>{formatDate(sermon.createdAt)}</Text>
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
+  superContainer: {
+    flex: 1,
+    backgroundColor: "#fff",
+  },
   container: {
     flex: 1,
-    alignItems: "center",
-    backgroundColor: "#fff",
   },
   sermonsContainer: {
-    flex: 1,
-    flexDirection: "row",
-    justifyContent: "center",
     verticalAlign: "middle",
     backgroundColor: "#fff",
-    padding: 50,
+    padding: 24,
+  },
+  sermonContainer: {
+    marginVertical: 10,
   },
   title: {
-    fontSize: 24,
+    fontSize: 28,
     fontWeight: "bold",
-    paddingVertical: 20,
+    marginTop: 24,
+    paddingHorizontal: 24,
   },
   sermonTitle: {
     fontSize: 18,
     fontWeight: "bold",
+    paddingTop: 10,
+  },
+  sermonDescription: {
+    fontSize: 16,
+    paddingTop: 10,
+  },
+  sermonDate: {
+    fontSize: 14,
+    paddingTop: 10,
   },
   buttonContainer: {
+    position: "absolute",
+    bottom: 0,
     flexDirection: "row",
-    justifyContent: "flex-end",
-    width: "80%",
+    justifyContent: "space-evenly",
+    width: "100%",
+    padding: 30,
+    backgroundColor: colors.darkPaper,
   },
-  button: {
-    marginHorizontal: 10,
-  },
+  button: {},
 });

--- a/src/screens/SermonsScreen.tsx
+++ b/src/screens/SermonsScreen.tsx
@@ -1,0 +1,131 @@
+import { FontAwesome5 } from "@expo/vector-icons";
+import { Audio } from "expo-av";
+import { getDownloadURL, ref } from "firebase/storage";
+import React, { useEffect, useState } from "react";
+import {
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { storage } from "../../firebase";
+import colors from "../styles/colors";
+
+export default function SermonsScreen() {
+  const [sound, setSound] = useState<any>();
+
+  useEffect(() => {
+    return sound
+      ? () => {
+          console.log("Unloading sound...");
+          sound.unloadAsync();
+        }
+      : undefined;
+  }, [sound]);
+
+  console.log("sound", sound);
+
+  async function pauseSound() {
+    console.log("Pausing sound...");
+    if (sound) {
+      await sound.pauseAsync();
+    }
+  }
+
+  async function stopSound() {
+    console.log("Stopping sound...");
+    if (sound) {
+      await sound.stopAsync();
+      await sound.unloadAsync();
+      setSound(null);
+    }
+  }
+
+  const playSound = async () => {
+    console.log("Playing sound...");
+    if (sound) {
+      console.log("Sound is loaded, resuming...");
+      sound.playAsync();
+    } else {
+      console.log("Sound is not loaded, loading...");
+      const sermon = ref(storage, "bella-on-love.mp3");
+      const uri = await getDownloadURL(sermon);
+      const { sound: playbackObject } = await Audio.Sound.createAsync(
+        { uri },
+        { shouldPlay: true }
+      );
+      setSound(playbackObject);
+    }
+  };
+
+  // TODO: Return a list of all sermons in Firebase Storage
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Sermons</Text>
+      <Sermon onPlay={playSound} onPause={pauseSound} onStop={stopSound} />
+    </SafeAreaView>
+  );
+}
+
+interface SermonProps {
+  onPlay: () => void;
+  onPause: () => void;
+  onStop: () => void;
+}
+
+function Sermon(props: SermonProps) {
+  const { onPlay, onPause, onStop } = props;
+
+  return (
+      <View style={styles.sermonsContainer}>
+        <View>
+          <Text style={styles.sermonTitle}>On Love</Text>
+        </View>
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity style={styles.button} onPress={onPlay}>
+            <FontAwesome5 name="play" size={24} color={colors.blue} />
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.button} onPress={onPause}>
+            <FontAwesome5 name="pause" size={24} color={colors.blue} />
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.button} onPress={onStop}>
+            <FontAwesome5 name="stop" size={24} color={colors.blue} />
+          </TouchableOpacity>
+        </View>
+      </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    backgroundColor: "#fff",
+  },
+  sermonsContainer: {
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center",
+    verticalAlign: "middle",
+    backgroundColor: "#fff",
+    padding: 50,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "bold",
+    paddingVertical: 20,
+  },
+  sermonTitle: {
+    fontSize: 18,
+    fontWeight: "bold",
+  },
+  buttonContainer: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    width: "80%",
+  },
+  button: {
+    marginHorizontal: 10,
+  },
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,27 @@
+import { Timestamp } from "@firebase/firestore";
+
+export const ensureDate = (date: Date | Timestamp): Date => {
+  if (date instanceof Date) {
+    return date;
+  }
+
+  if (typeof date === "string") {
+    return new Date(date);
+  }
+
+  if (date instanceof Timestamp) {
+    return date.toDate();
+  }
+
+  return new Date();
+};
+
+export const formatDate = (date: Date | Timestamp): string => {
+  const d = ensureDate(date);
+  return d.toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,3 +25,13 @@ export const formatDate = (date: Date | Timestamp): string => {
     day: "numeric",
   });
 };
+
+// Format time
+export const formatTime = (date: Date | Timestamp): string => {
+  const d = ensureDate(date);
+  return d.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "numeric",
+    hour12: true,
+  });
+};

--- a/types.ts
+++ b/types.ts
@@ -6,5 +6,6 @@ export type TSermon = {
   title: string;
   description: string;
   createdAt: Date | Timestamp;
+  speaker: string;
 };
 

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,10 @@
+import { Timestamp } from "@firebase/firestore";
+
+export type TSermon = {
+  id: string;
+  filename: string;
+  title: string;
+  description: string;
+  createdAt: Date | Timestamp;
+};
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -3657,6 +3657,11 @@ expo-asset@~8.7.0:
     path-browserify "^1.0.0"
     url-parse "^1.5.9"
 
+expo-av@^13.0.2:
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/expo-av/-/expo-av-13.0.2.tgz#06c2c5140b334319ed2844823181f7b88092da13"
+  integrity sha512-u+y9wUBodp08UjRZYckNWzr9zEQHK6eScRBkhdTd9Rq48SEZ7eN6xXn79hubvk0P5nj7lFS+hdKjmx9T5XHGww==
+
 expo-constants@~14.0.0, expo-constants@~14.0.2:
   version "14.0.2"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-14.0.2.tgz#2cb1dec8f41a64c2fc5b4eecaf77d7661cad01cc"


### PR DESCRIPTION
https://github.com/jacogrande/FaithForwardFirebase/pull/6

Still plotting UX, but thinking Firebase could cron a fresh sermon from GPT and Eleven Labs at whatever frequency we want -- probably daily -- and send a push notification about it.

Plus it's a pushbutton dopamine hit. Still want to figure out how to add a flow to devotionals that's closer to pushbutton too, but sermons and a full Bible reader make the app usable when OpenAI APIs are inevitably down (I mean have you seen their status page, oy vey)

![Screenshot 2023-02-14 at 22 02 17](https://user-images.githubusercontent.com/788415/218926191-03c67514-327f-41a2-a504-e02f774d7556.png)
