### PR TITLE
Enable refreshing sermons list

### DIFF
--- a/src/hooks/useSermons.ts
+++ b/src/hooks/useSermons.ts
@@ -4,9 +4,17 @@ import { db } from "../../firebase";
 import { TSermon } from "../../types";
 import useStore from "../Store";
 
-export const useSermons = () => {
+type Signature = {
+  sermons: TSermon[];
+  loading: boolean;
+  refreshing: boolean;
+  setRefreshing: (refreshing: boolean) => void;
+};
+
+export const useSermons = (): Signature => {
   const [sermons, setSermons] = useState<TSermon[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const { setError } = useStore();
 
   // Fetch sermons from Firestore
@@ -31,12 +39,15 @@ export const useSermons = () => {
       setError(error.toString());
     } finally {
       setLoading(false);
+      setRefreshing(false);
     }
   };
 
   useEffect(() => {
-    fetchSermons();
-  }, []);
+    if (loading || refreshing) {
+      fetchSermons();
+    }
+  }, [refreshing]);
 
-  return { sermons, loading };
+  return { sermons, loading, refreshing, setRefreshing };
 };

--- a/src/screens/SermonsScreen.tsx
+++ b/src/screens/SermonsScreen.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from "react";
 import {
   ActivityIndicator,
   FlatList,
+  RefreshControl,
   SafeAreaView,
   StyleSheet,
   Text,
@@ -18,7 +19,7 @@ import { useSermons } from "../hooks/useSermons";
 import colors from "../styles/colors";
 
 export default function SermonsScreen() {
-  const { sermons, loading } = useSermons();
+  const { sermons, loading, refreshing, setRefreshing } = useSermons();
   const [sound, setSound] = useState<any>();
   const [playingSermon, setPlayingSermon] = useState<TSermon | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -178,6 +179,12 @@ export default function SermonsScreen() {
             )}
             ListEmptyComponent={<Text>No sermons to display.</Text>}
             ListFooterComponent={<View style={{ height: 100 }} />}
+            refreshControl={
+              <RefreshControl
+                refreshing={refreshing}
+                onRefresh={() => setRefreshing(true)}
+              />
+            }
           />
         )}
         {!!sound ? (


### PR DESCRIPTION
Doesn't automatically refresh. Could've added constant polling, but I think that's overkill.

Pull to refresh is pretty common UX, easy to implement, and I'm guessing intuitive for users who expect new content here.

Honestly crucial enough that we should probably push a new minor release for it.